### PR TITLE
fix sha1 code

### DIFF
--- a/book_maker.py
+++ b/book_maker.py
@@ -3,35 +3,25 @@ import jinja2
 import hashlib
 
 
-def sha1(filename):
-    s = hashlib.sha1()
-    s.update(filename.encode('utf-8'))
-    return s.hexdigest()
-
-
-def render_parameterized_notebook(templatefn, outfn, params):
-    with open(templatefn) as f:
-        templ = jinja2.Template(f.read())
-
-    result = templ.render(**params)
-    with open(outfn, 'w') as f:
-            f.write(result)
-
-
 def make_notebook_from_params(paramdct):
     templatefn = os.path.join('templates', paramdct.pop('template'))
     if not os.path.exists(templatefn):
         templatefn = templatefn + '.ipynb'
 
-    basename = os.path.splitext(os.path.split(templatefn)[1])[0]
-    basename_sha1 = basename + sha1(str(paramdct))
-    outnbfn = os.path.join('output_nbs', basename_sha1) + '.ipynb'
+    with open(templatefn) as f:
+        templ = jinja2.Template(f.read())
 
-    if os.path.exists(outnbfn):
-        os.unlink(outnbfn)
-    render_parameterized_notebook(templatefn, outnbfn, paramdct)
+    result = templ.render(**paramdct)
 
-    return outnbfn
+    # determine the output file name as the sha1 hash of the template name + content of the file
+    s = hashlib.sha1(templatefn.encode('utf-8'))
+    s.update(result.encode('utf-8'))
+    outfn = os.path.join('output_nbs', s.hexdigest() + '.ipynb')
+
+    with open(outfn, 'w') as f:
+        f.write(result)
+
+    return outfn
 
 
 def generate_html_from_notebook():


### PR DESCRIPTION
This is a fix to @barentsen's SHA1 implementation.  This version uses the *content* of the output file instead of its file *name*, which I think makes it more robust to changing content in the template.  (This I think is what I was enivsioning but didn't say too clearly).

:+1: @barentsen ?